### PR TITLE
Link to default CSS served by GH Pages

### DIFF
--- a/paged-wp.php
+++ b/paged-wp.php
@@ -70,7 +70,7 @@ function paged_enqueue_preview_css() {
 	if ( is_page() && is_preview() && paged_is_paged_preview() ) {
 		wp_enqueue_style(
 			'paged-css-main',
-			'https://raw.githubusercontent.com/electricbookworks/book-css/master/css/themes/default/main.css',
+			'https://electricbookworks.github.io/book-css/css/themes/default/main.css',
 			array(),
 			time()
 		);


### PR DESCRIPTION
GitHub serves raw files with a text/plain MIME type, which causes Chrome to show an error.

Linking to the CSS file GH serves via GitHub Pages avoids this issue.

All good, @jonathanbossenger?