### PR TITLE
Add wrapper div for targeting with @page rules

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -12,6 +12,7 @@
 </head>
 
 <body>
+	<div class="paged-wp">
 
 <?php
 /* Start the Loop */
@@ -23,5 +24,6 @@ endwhile; // End of the loop.
 
 <?php do_action( 'paged_foot' ); ?>
 
+	</div>
 </body>
 </html>


### PR DESCRIPTION
@jonathanbossenger Is this minor change okay?

This adds a wrapper `div class="paged-wp"`, which seems to be necessary for targeting groups of pages with `@page` rules, for things like page numbers. I'm not sure yet why that is, and I suspect that in a future release we may need to inject this class from a custom field that the user sets per page/post.