### PR TITLE
Minor fix to default cover styles syntax

### DIFF
--- a/assets/css/paged.css
+++ b/assets/css/paged.css
@@ -3764,10 +3764,11 @@ pre + p {
     color: #0000cf;
     font-weight: bold; }
 
-@page .cover {
+@page cover {
           margin: 0; }
 
 .cover {
+    page: cover;
     margin: 0;
     padding: 0;
     position: absolute;


### PR DESCRIPTION
@jonathanbossenger This is a tiny fix for a syntax error in the original default `paged.css`.